### PR TITLE
Change the amount input type from "text" to "number".

### DIFF
--- a/src/containers/Trade.svelte
+++ b/src/containers/Trade.svelte
@@ -235,7 +235,7 @@
     <div class="control is-expanded">
       <input
         class="input is-large has-background-dark has-text-white has-text-right"
-        type="text"
+        type="number"
         placeholder="0.00"
         bind:value={sendAmount}
         on:input={onSendAmountChange}
@@ -263,7 +263,7 @@
     <div class="control is-expanded">
       <input
         class="input is-large has-background-dark has-text-white has-text-right"
-        type="text"
+        type="number"
         placeholder="0.00"
         bind:value={receiveAmount}
         on:input={onReceiveAmountChange}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -34,9 +34,14 @@ $modal-background-background-color: "transparent";
       height: 80px;
       width: 80px;
     }
-    
+
   &.is-active {
       opacity: 1;
       z-index: 1;
   }
+}
+
+// Remove arrows from input type number
+input[type=number] {
+  -moz-appearance: textfield;
 }


### PR DESCRIPTION
This increase UX when using mobile and assistive devices:
- built-in validation to reject non-numerical entries;
- the browser may opt to allow for mouse scrolling to increase or decrease the amount;
- the browser may opt to provide stepper arrows to let the user increase and decrease the value using their mouse or by tapping with a fingertip.

Having said that, this pull request also includes some CSS code to hide the stepper arrows (for aesthetics purposes only)