### PR TITLE
Add fiat values

### DIFF
--- a/src/components/FiatRow.svelte
+++ b/src/components/FiatRow.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { FiatSymbol } from '../constants';
+  export let name;
+</script>
+
+<div class="columns is-mobile is-vcentered">
+  <div class="column is-one-third">
+    <p>{FiatSymbol[name]}</p>
+  </div>
+  <div class="column is-two-third">
+    <p>{name}</p>
+  </div>
+</div>

--- a/src/components/FiatValue.svelte
+++ b/src/components/FiatValue.svelte
@@ -12,12 +12,10 @@
     const res = await fetch(`${endpoint}?vs_currency=${currency}&ids=${id}`);
     const json = await res.json();
 
-    if (res.ok) {
-      const value = (json[0].current_price * amount).toFixed(2);
-      return `${FiatSymbol[fiat]} ${value}`;
-    } else {
-      throw new Error(json);
-    }
+    if (!res.ok) throw new Error(json);
+    
+    const value = (json[0].current_price * amount).toFixed(2);
+    return `${FiatSymbol[fiat]} ${value}`;
   }
 
   let id;

--- a/src/components/FiatValue.svelte
+++ b/src/components/FiatValue.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { CoinGeckoId, FiatSymbol } from "../constants";
+
+  export let coin;
+  export let amount;
+  export let fiat;
+
+  async function getValue(id, amount, currency) {
+    if (!id || !amount || !currency) return;
+
+    const endpoint = 'https://api.coingecko.com/api/v3/coins/markets';
+		const res = await fetch(`${endpoint}?vs_currency=${currency}&ids=${id}`);
+		const json = await res.json();
+
+		if (res.ok) {
+      const value = (json[0].current_price * amount).toFixed(2);
+      return `${FiatSymbol[fiat]} ${value}`;
+		} else {
+			throw new Error(json);
+		}
+	}
+
+  let id;
+  let currency;
+  let promise;
+  let visible;
+
+  $: id = CoinGeckoId[coin];
+  $: currency = CoinGeckoId[fiat]
+  $: promise = getValue(id, amount, currency);
+  $: visible = amount && id;
+</script>
+
+{#if visible}
+  {#await promise then value}
+    <p>{value}</p>
+  {/await}
+{/if}
+
+<style>
+  p {
+    color: white;
+    padding-bottom: 1em;
+    padding-right: calc(1.25em - 2px);
+    text-align: right;
+  }
+</style>

--- a/src/components/FiatValue.svelte
+++ b/src/components/FiatValue.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { CoinGeckoId, FiatSymbol } from "../constants";
+  import { CoinGeckoId, FiatSymbol } from '../constants';
 
   export let coin;
   export let amount;
@@ -9,16 +9,16 @@
     if (!id || !amount || !currency) return;
 
     const endpoint = 'https://api.coingecko.com/api/v3/coins/markets';
-		const res = await fetch(`${endpoint}?vs_currency=${currency}&ids=${id}`);
-		const json = await res.json();
+    const res = await fetch(`${endpoint}?vs_currency=${currency}&ids=${id}`);
+    const json = await res.json();
 
-		if (res.ok) {
+    if (res.ok) {
       const value = (json[0].current_price * amount).toFixed(2);
       return `${FiatSymbol[fiat]} ${value}`;
-		} else {
-			throw new Error(json);
-		}
-	}
+    } else {
+      throw new Error(json);
+    }
+  }
 
   let id;
   let currency;
@@ -26,7 +26,7 @@
   let visible;
 
   $: id = CoinGeckoId[coin];
-  $: currency = CoinGeckoId[fiat]
+  $: currency = CoinGeckoId[fiat];
   $: promise = getValue(id, amount, currency);
   $: visible = amount && id;
 </script>

--- a/src/components/FiatValue.svelte
+++ b/src/components/FiatValue.svelte
@@ -13,7 +13,7 @@
     const json = await res.json();
 
     if (!res.ok) throw new Error(json);
-    
+
     const value = (json[0].current_price * amount).toFixed(2);
     return `${FiatSymbol[fiat]} ${value}`;
   }

--- a/src/components/SelectFiatModal.svelte
+++ b/src/components/SelectFiatModal.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import FiatRow from './FiatRow.svelte';
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  import { Fiat } from '../constants';
+
+  export let active: boolean;
+
+  const onCancel = () => {
+    active = false;
+  };
+
+  const onSelect = (fiat: string) => {
+    dispatch('selected', { fiat });
+    active = false;
+  };
+</script>
+
+<div class="modal {active && 'is-active'}">
+  <div class="modal-background" on:click={onCancel} />
+  <div class="modal-content box has-background-black">
+    <div class="columns">
+      <div class="column is-half is-offset-one-quarter">
+        <h1 class="title has-text-white">Select an asset</h1>
+        <ul class="mt-6">
+          <li class="mt-3">
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a on:click={() => onSelect(Fiat.CAD)}>
+              <FiatRow name={Fiat.CAD} />
+            </a>
+          </li>
+          <li class="mt-3">
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a on:click={() => onSelect(Fiat.EUR)}>
+              <FiatRow name={Fiat.EUR} />
+            </a>
+          </li>
+          <li class="mt-3">
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a on:click={() => onSelect(Fiat.USD)}>
+              <FiatRow name={Fiat.USD} />
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  a {
+    color: white;
+  }
+</style>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -29,6 +29,26 @@ export const CoinTicker: Record<string,string> = {
   [Coin.LCAD]: "LCAD"
 };
 
+export enum Fiat {
+  CAD = "Canadian dollar",
+  EUR = "Euro",
+  USD = "US dollar",
+};
+
+export const FiatSymbol: Record<string,string> = {
+  [Fiat.CAD]: "C$",
+  [Fiat.EUR]: "€",
+  [Fiat.USD]: "$"
+};
+
+// used on FiatValue component
+export const CoinGeckoId: Record<string,string> = {
+  [Coin.Bitcoin]: "bitcoin",
+  [Coin.Tether]: "tether",
+  [Fiat.CAD]: "cad",
+  [Fiat.EUR]: "eur",
+  [Fiat.USD]: "usd",
+};
 
 const LIQUID_BTC = '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d';
 const LIQUID_USDT = 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2';

--- a/src/containers/Trade.svelte
+++ b/src/containers/Trade.svelte
@@ -138,7 +138,7 @@
       const precision = CoinToAssetByChain['liquid'][toCoin].precision;
       const firstPriceAmount = fromSatoshi(
         firstPrice.amount.toString(),
-        precision,
+        precision
       );
       coinsRatio = parseFloat(
         (firstPriceAmount.toNumber() / amount).toFixed(precision)
@@ -158,11 +158,11 @@
 
   const onSendAmountChange = async () => {
     onAmountChange('send');
-  }
+  };
 
   const onReceiveAmountChange = async () => {
     onAmountChange('receive');
-  }
+  };
 
   const onTradeSubmit = async () => {
     const identity = new BrowserInjectIdentity({

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -34,7 +34,7 @@ $modal-background-background-color: "transparent";
       height: 80px;
       width: 80px;
     }
-    
+
   &.is-active {
       opacity: 1;
       z-index: 1;


### PR DESCRIPTION
Fiat values via Coingecko API
Add modal to choose fiat currency (cad, euro and usd)
Add coins ratio (ex: 1 L-BTC = 56789 USDt)
DRY code on onSendAmountChange and onReceiveAmountChange
Update values automatically on coin change

Live on https://joaobordalo.com/labs/dex/