### PR TITLE
Show loading message while waiting for tdex markets

### DIFF
--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -22,10 +22,10 @@
   const messages = {
     loading: 'Loading...',
     timeout: 'Something went wrong.',
-  }
+  };
   let message = messages.loading;
   const timeoutDelay = 60 * 1000; // 60 seconds
-  setTimeout(() => message = messages.timeout, timeoutDelay);
+  setTimeout(() => (message = messages.timeout), timeoutDelay);
   $: message;
 </script>
 

--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -20,7 +20,7 @@
   // Show a loading message while we wait for tdex markets
   // After a timeout delay, show a different message
   const messages = {
-    loading: 'Loading...',
+    loading: 'Discovering TDEX providers...',
     timeout: 'Something went wrong.',
   };
   let message = messages.loading;

--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -16,6 +16,17 @@
     dispatch('selected', { coin });
     active = false;
   };
+
+  // Show a loading message while we wait for tdex markets
+  // After a timeout delay, show a different message
+  const messages = {
+    loading: 'Loading...',
+    timeout: 'Something went wrong.',
+  }
+  let message = messages.loading;
+  const timeoutDelay = 60 * 1000; // 60 seconds
+  setTimeout(() => message = messages.timeout, timeoutDelay);
+  $: message;
 </script>
 
 <div class="modal {active && 'is-active'}">
@@ -24,16 +35,20 @@
     <div class="columns">
       <div class="column is-half is-offset-one-quarter">
         <h1 class="title has-text-white">Select an asset</h1>
-        <ul class="mt-6">
-          {#each tradableCoins as coin}
-            <li class="mt-3">
-              <!-- svelte-ignore a11y-missing-attribute -->
-              <a on:click={() => onSelect(coin)}>
-                <CoinRow {coin} />
-              </a>
-            </li>
-          {/each}
-        </ul>
+        {#if tradableCoins.length > 0}
+          <ul class="mt-6">
+            {#each tradableCoins as coin}
+              <li class="mt-3">
+                <!-- svelte-ignore a11y-missing-attribute -->
+                <a on:click={() => onSelect(coin)}>
+                  <CoinRow {coin} />
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="has-text-white">{message}</p>
+        {/if}
       </div>
     </div>
   </div>

--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -22,7 +22,7 @@
   enum MESSAGES {
     loading = 'Discovering TDEX providers...',
     timeout = 'All TDEX providers are not available. Try again later',
-  };
+  }
   let message = MESSAGES.loading;
   const timeoutDelay = 60 * 1000; // 60 seconds
   setTimeout(() => (message = MESSAGES.timeout), timeoutDelay);

--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -21,7 +21,7 @@
   // After a timeout delay, show a different message
   const messages = {
     loading: 'Discovering TDEX providers...',
-    timeout: 'Something went wrong.',
+    timeout: 'All TDEX providers are not available. Try again later',
   };
   let message = messages.loading;
   const timeoutDelay = 60 * 1000; // 60 seconds

--- a/src/components/SelectCoinModal.svelte
+++ b/src/components/SelectCoinModal.svelte
@@ -19,13 +19,13 @@
 
   // Show a loading message while we wait for tdex markets
   // After a timeout delay, show a different message
-  const messages = {
-    loading: 'Discovering TDEX providers...',
-    timeout: 'All TDEX providers are not available. Try again later',
+  enum MESSAGES {
+    loading = 'Discovering TDEX providers...',
+    timeout = 'All TDEX providers are not available. Try again later',
   };
-  let message = messages.loading;
+  let message = MESSAGES.loading;
   const timeoutDelay = 60 * 1000; // 60 seconds
-  setTimeout(() => (message = messages.timeout), timeoutDelay);
+  setTimeout(() => (message = MESSAGES.timeout), timeoutDelay);
   $: message;
 </script>
 


### PR DESCRIPTION
Fixes #12 

Opted for a lighter solution (no need for a popup), since this not happens very often:

1. Tdex markets must be slow, and
2. User must click on the coin selection in the first seconds on the site.

It's just a "Loading..." message that changes to "Something went wrong" after 60 seconds and disappears when the markets respond.

@tiero please review