### PR TITLE
adds loading modal

### DIFF
--- a/src/components/LoadingModal.svelte
+++ b/src/components/LoadingModal.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { allTradableAssets } from '../stores/tdexstore';
+
+  // Messages to show to user while loading tdex markets
+  enum MESSAGES {
+    loading = 'Discovering TDEX providers...',
+    timeout = 'No TDEX provider is available. Try again later.',
+  }
+
+  let showModal = true;
+  let isLoading = true;
+
+  // Change message after some delay
+  // User will only see this if tdex markets didn't respond
+  const loadingTimeout = 60 * 1000; // 60 seconds
+  setTimeout(() => (isLoading = false), loadingTimeout);
+
+  // Hide modal when tdex markets respond
+  allTradableAssets.subscribe((assets) => {
+    if (assets.length > 0) showModal = false;
+  });
+</script>
+
+<div class="modal {showModal && 'is-active'}">
+  <div class="modal-background" />
+  <div class="modal-content box has-background-black has-text-centered">
+    <h1 class="title has-text-white">
+      {isLoading ? MESSAGES.loading : MESSAGES.timeout}
+    </h1>
+    {#if isLoading}
+      <div class="loader-wrapper is-active">
+        <div class="loader is-loading" />
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/containers/Trade.svelte
+++ b/src/containers/Trade.svelte
@@ -29,6 +29,7 @@
   import { allTradableAssets, tdexStore } from '../stores/tdexstore';
   import { marinaStore } from 'svelte-marina-button';
   import { utxoStore } from '../stores/utxostore';
+  import LoadingModal from '../components/LoadingModal.svelte';
 
   utxoStore.subscribe(() => null); // trigger utxo update
 
@@ -302,6 +303,7 @@
   {receiveAmount}
   receiveCoin={pair.receive}
 />
+<LoadingModal />
 
 <style>
   .coin-button {


### PR DESCRIPTION
Fixes #12 

- Shows a loading modal while getting information from TDEX markets.
- Is not possible to manually close the modal (user has to wait).
- As soon as TDEX markets information is received, the modal is closed.
- If no information its received for 60 seconds, the message is changed.

Messages:
- While loading: `Discovering TDEX providers...` + spinner
- After 60 seconds: `No TDEX provider is available. Try again later.`

@tiero please review.