### PR TITLE
Fix `computeOrders` function

### DIFF
--- a/src/utils/tdex.ts
+++ b/src/utils/tdex.ts
@@ -75,9 +75,6 @@ export function computeOrders(
   const orders: TradeOrder[] = [];
   for (const [providerEndpoint, markets] of Object.entries(marketsByProvider)) {
     orders.push(...tdexOrdersForProvider(pair, providerEndpoint, markets));
-    if (orders.length > 0) {
-      return orders;
-    }
   }
 
   return orders;


### PR DESCRIPTION
This PR is a fix of the `computeOrders` function.
It now computes orders for **all the providers**, thus the discovery now requests all available providers instead of only one.

it closes #22 

@tiero @bordalix  please review